### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -1,0 +1,26 @@
+name: Rust CI
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - prod
+    tags:
+      - '**'
+
+jobs:
+  cargo-deny:
+    name: Licensing and Advisories
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4.2.1
+      - uses: EmbarkStudios/cargo-deny-action@8371184bd11e21dcf8ac82ebf8c9c9f74ebf7268 # pin@v2.0.1
+
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4.2.1
+      - name: Run cargo format
+        run: cargo fmt --all --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "hyrax"
-version = "0.1.0"
+version = "0.0.0"
+repository = "https://github.com/worldcoin/remainder-hyrax-tfh"
 edition = "2021"
+publish = false
 
 [dependencies]
 itertools = "0.11.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add a FOSS license

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,53 @@
+[graph]
+# Cargo deny will check dependencies via `--all-features`
+all-features = true
+
+[advisories]
+version = 2
+ignore = [
+]
+
+[sources]
+unknown-registry = "deny"
+
+[licenses]
+version = 2
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 1.0
+
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+allow = [
+    "0BSD",
+    "Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-2-Clause-Patent",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "LicenseRef-ring",
+    "LicenseRef-wc-proprietary",
+    "MIT",
+    "MPL-2.0", # Although this is copyleft, it is scoped to modifying the original files
+    "OpenSSL",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "Zlib",
+]
+
+# See https://github.com/briansmith/ring/blob/95948b3977013aed16db92ae32e6b8384496a740/deny.toml#L12
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "hyrax"
+expression = "LicenseRef-wc-proprietary"
+license-files = [
+	{ path = "LICENSE", hash = 0xeafa4d94 }
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.81.0" # See Cargo.toml
+targets = ["aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"]
+profile = "minimal"
+components = ["clippy", "llvm-tools-preview", "rustfmt", "rust-src", "rust-analyzer"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# Use default cargo settings


### PR DESCRIPTION
This PR does the following:
* pins the rust toolchain to latest stable. Ensures that over time as rust updates, CI won't break. Updating rust can be done at any time by updating the toolchain.
* Sets the "Minimum supported rust version" to be the latest. I don't actually know which rust version is the oldest one you wish to support, so I figured setting it to the latest would be fine.
* Adds CI to check that all dependencies are permissively licensed (aka no GPL)
* Adds CI to ensure that code complies with the format declared in `rustfmt.toml`