### PR TITLE
use caret instead of tilde versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0"
 sha3 = { version = "0.8.2", default-features = false }
 bincode = "1.3.3"
-clap = { version = "~4.4", features = ["derive"] }
+clap = { version = "4.4.0", features = ["derive"] }
 ark-ec = "0.4.2"
 ark-ff = "0.4.2"
 ark-serialize = "0.4"


### PR DESCRIPTION
The `~` version selector is more restrictive than the default selector. Using the tilde causes conflicts for anyone on a version of clap not in 4.4.X.

Read more [here](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements)